### PR TITLE
add version selection to keyword/author

### DIFF
--- a/verse.py
+++ b/verse.py
@@ -18,15 +18,18 @@ class DailyVerse(IQuoteSource):
 		}
 
 	def supports_search(self):
-		return False
+		return True
 
-	def get_random(self):
-		version = 'ESV'
+	@staticmethod
+	def get_verse(version):
 		response = json.loads(requests.get('https://www.biblegateway.com/votd/get/?format=json&version=' + version).content)
 		return [{'quote': unescape(response['votd']['text']), 'author': response['votd']['display_ref'], 'sourceName': None, 'link': None}]
 
+	def get_random(self):
+		return self.get_verse('ESV')
+
 	def get_for_author(self, author):
-		return []
+		return self.get_verse(author)
 
 	def get_for_keyword(self, keyword):
-		return []
+		return self.get_verse(keyword)


### PR DESCRIPTION
This removes the requirement to manually edit the script in favor of defining the version(s) in "Tags"/"Authors":
![image](https://github.com/Crissium/variety-daily-verse/assets/19600707/3ab70f21-e5ce-46f5-8aa2-84faea15a3ea)

I wasn't sure which would fit better, so I decided to do both since this ensures that even if the user is unsure, it will still work.